### PR TITLE
fix: update serial port regex to support raspberrypi serial devices (/dev/ttyAMA*)

### DIFF
--- a/vedirect_m8/serutils.py
+++ b/vedirect_m8/serutils.py
@@ -61,7 +61,7 @@ class SerialUtils (UType):
         """Test if is valid serial port name pattern."""
         return SerialUtils.is_str(data) and SerialUtils.is_list(
             re.compile(
-                r'^((?:tty(?:USB|ACM)|vmodem|COM)\d{1,3})$'
+                r'^((?:tty(?:USB|ACM|AMA)|vmodem|COM)\d{1,3})$'
             ).findall(data),
             not_null=True
         )


### PR DESCRIPTION
Serial ports on many versions of Raspberry PI appear as devices with the prefix `/dev/ttyAMA`. Some notes can be found here: https://elinux.org/RPi_Serial_Connection

This change updates the regular expression that asserts a correctly formed port to provide compatibility with RPI serial.

I don't see tests that assert the behavior of correct formats, just some tests to assert behavior when a bad port is provided. Thus, not going to make changes to tests - please let me know if I should consider otherwise.